### PR TITLE
Imperative -> Declarative: Part 1

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,7 +16,10 @@ class ApplicationController < Sinatra::Base
   end
 
   post "/message" do
-    my_message = Message.new
-    my_message.translate_and_send(params[:phoneNumber], params[:language], params[:content])
+    # create an instance of a message, supplying the necessary data...
+    my_message = Message.new(params[:phoneNumber], params[:language], params[:content])
+    # and `send!` it! `send!` knows how to translate it and where to send it
+    # because that's stored on the instance and is available to every method.
+    my_message.send!
   end
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,33 +1,100 @@
 require "faraday"
 require "twilio-ruby"
-class Message < ActiveRecord::Base
 
+# Since we don't actually save our Message to
+# the database, it doesn't need to be an
+# ActiveRecord model (because AcctiveRecord
+# provides all the database abstractions).
+# It can be a plain Ruby object instead.
+class Message
+  # Every time we create a new Message instance,
+  # we want it to remember what the message's
+  # recipient, langauge, and content are, so that
+  # we can refer to them later. Since
+  # `to` is a preposition and `recipient` is a
+  # noun, we'll use that varaible name.
+  # And since `language` is ambiguous
+  # (source language or target language?)
+  # we'll specify that too.
+  def initialize(recipient, target_language, content)
+    # Here we use instance variables because we
+    # want to keep track of a Message's language
+    # and content across the entire instance,
+    # including all it's methods.
+    @recipient = recipient
+    @target_language = target_language
+    @content = content
+  end
 
+  # get_translation returns the translation for the
+  # Message's content based on it's language.
+  # Note that the Message's content isn't updated;
+  # a whole new string is returned.
 
-  def translate_and_send(phoneNumber, language, content)
+  def get_translation
+    # Even though we're defining a whole new method,
+    # we want it to have access to the same language
+    # and content as when its instance was created
+    # (so we again use the instance variables).
     resp = Faraday.get 'https://translate.yandex.net/api/v1.5/tr.json/translate' do |req|
-      req.params['lang'] = "en-#{language}"
+      req.params['lang'] = "en-#{@target_language}" # this is easier to reason about w/ the new variable name
       req.params['key'] = ENV['YANDEX_API_KEY']
-      req.params['text'] = content
+      req.params['text'] = @content
     end
 
-    body = JSON.parse(resp.body)
-    if resp.success?
-      translated = body["text"][0]
-      send(phoneNumber, translated)
+    # The Ruby documentation for JSON.parse says:
+    #
+    # > parse(source, opts = {})
+    # >
+    # > Parse the JSON document `source` into a Ruby data structure
+    # > and return it.
+    #
+    # Since it returns a Ruby data structure, and the input
+    # data is a JSON document with a top-level JS hash,
+    # the return data structure will be a Ruby hash.
+    # Rember, `data.success?` is a method call (for a
+    # method named `success?` on the hash `data`).
+    # But no such method exists; in fact, if you look
+    # at the response from a Yandex translate call,
+    # it only has the properties `code`,
+    # `lang`, and the `text` array. So it's successful
+    # if the code is 200, and failed otherwise,
+    # as per https://tech.yandex.com/translate/doc/dg/reference/translate-docpage/#codes
+    data = JSON.parse(resp.body)
+    if data['code'] == 200
+      # We just want to return the text from the data.
+      # We don't have to assign it to anything, or use
+      # `return`, just make it the last expression.
+      data["text"][0]
+      # Note that we no longer call `send` here.
+      # The purpose of this method, per it's name,
+      # is to get the translation for the Message object
+      # the method was called on.
     else
-      raise ArgumentError, body
+      # If it failed, whoever called this method
+      # has to deal with it.
+      raise RuntimeError, "Unexpcted Yandex code returned: #{data['code']}"
     end
   end
 
-  def send(to, translated)
+  # In this case, when we call `send`, we're telling it to
+  # do a thing that has a side effect (in this case, send a translated
+  # text message). Sometimes Rubyists name a method like this
+  # with a bang, to make sure you know you're actually gonna do
+  # something with this method instead of just return new data.
+  def send!
+    # But instead of passing `to` and `translated` as arguments
+    # like we used to, we can just access data and methods on
+    # the instance, thus removing duplication of data.
+    translated = self.get_translation()
+
     client = Twilio::REST::Client.new(
       ENV['TWILIO_ACCOUNT_SID'],
       ENV['TWILIO_AUTH_TOKEN'])
 
     client.messages.create(
       from: ENV['TWILIO_PHONE_NUMBER'],
-      to: to,
+      to: @recipient, # the recipient is stored on the instance
       body: translated
     )
   end


### PR DESCRIPTION
First of all, let's figure out if our current controller code is more imperative or declarative:

```ruby
# original code
my_message = Message.new
my_message.translate_and_send(params[:phoneNumber], params[:language], params[:content])
```

At first this might seem declarative; after all, we're saying that `my_message` is a message, and that we want to translate and send it, not *how* to do those things. And while yes, that's technically true, in reality, the code isn't actually saying very much. Yes, `my_message` is `Message`, but it's the same as any other `Message`. There's literally no reason to create this variable at all except to get at the `translate_and_send` method which is attached to it. And if you look at `translate_and_send`:

```ruby
# original code
def translate_and_send(phoneNumber, language, content)
  resp = Faraday.get 'https://translate.yandex.net/api/v1.5/tr.json/translate' do |req|
    req.params['lang'] = "en-#{language}"
    req.params['key'] = ENV['YANDEX_API_KEY']
    req.params['text'] = content
  end

  body = JSON.parse(resp.body)
  if resp.success?
    translated = body["text"][0]
    send(phoneNumber, translated)
  else
    raise ArgumentError, body
  end
end
```

"Get this request, then parse the JSON, then send it to this phone number." Sounds pretty imperative to me.

(Note: one other problem with organizing code this way is that there's no way to test out the translation without also sending a text message — `translate_and_send` is the only thing a `Message` knows how to do! Why don't we split those up so that `Message`s are easier to reason about, easier to test on the console (and in automated tests), and easier to reuse in multiple contexts (because it can do more things).)

So instead, let's say what the message *really* is, and then say what we want to do with it. Well, a `Message` represents a translatable message, and so has a `recipient`, some `content`, and a `target_langauge`. So, since every instance of `Message` should have those things, let's make those attributes the instance variables for our class — every `Message` object will have its own value for these three variables, and all that instance's methods have access to them too.

```ruby
# new code
class Message
  def initialize(recipient, target_language, content)
    @recipient = recipient
    @target_language = target_language
    @content = content  
  end
```

Now that we know what `my_message` in our controller is, what do we want to do with it? Well, we want to send the translated message. So let's just tell it to `send!`.

```ruby
# new code
my_message = Message.new(params[:phoneNumber], params[:language], params[:content])
my_message.send!
```

We don't need to tell `send!` what translated text to send, or what number to send it to, because it can figure that out from the instance variables.

Well first, we need to get the translated message so that we can have Twilio send it.

```ruby
# new code, in the Message class
def send!
  translation = ### ?
end
```

Since don't want to have `send!` know all the specific steps to translating a message, this is a perfect thing to make into another method. This also means we can test it very easily on the Rails console! It also means we can keep working on `send!` without worrying about how to get the translation, making the function easier to think about. Let's just assume we'll be able to get the translation, and move on.

```ruby
# new code, in the Message class
def send!
  translation = self.get_translation()

  client = Twilio::REST::Client.new(
    ENV['TWILIO_ACCOUNT_SID'],
    ENV['TWILIO_AUTH_TOKEN'])

  client.messages.create(
    from: ENV['TWILIO_PHONE_NUMBER'],
    to: @recipient, # the recipient is stored on the instance
    body: translation
  )
end
```

That's done; now that we know we need a method on the `Message` instances called `get_translation`, so let's define it! (Additional descriptions for some of the other changes to the translation algorithm are listed in the code comments in the PR.)

```ruby
# new code, in the Message class
def get_translation
  resp = Faraday.get 'https://translate.yandex.net/api/v1.5/tr.json/translate' do |req|
    req.params['lang'] = "en-#{@target_language}"name
    req.params['key'] = ENV['YANDEX_API_KEY']
    req.params['text'] = @content
  end

  data = JSON.parse(resp.body)
  if data['code'] == 200
    data["text"][0]
  else
    raise RuntimeError, "Unexpcted Yandex code returned: #{data['code']}"
  end
end
```

And that's it! With just those changes, our code is more declarative, and in doing so have made it clearer and easier to test.

```ruby
# controller
  post "/message" do
    my_message = Message.new(params[:phoneNumber], params[:language], params[:content])
    my_message.send!
  end

# model
class Message
  def initialize(recipient, target_language, content)
    @recipient = recipient
    @target_language = target_language
    @content = content
  end

  def get_translation
    resp = Faraday.get 'https://translate.yandex.net/api/v1.5/tr.json/translate' do |req|
      req.params['lang'] = "en-#{@target_language}"
      req.params['key'] = ENV['YANDEX_API_KEY']
      req.params['text'] = @content
    end

    data = JSON.parse(resp.body)
    if data['code'] == 200
      data["text"][0]
    else
      raise RuntimeError, "Unexpcted Yandex code returned: #{data['code']}"
    end
  end

  def send!
    client = Twilio::REST::Client.new(
      ENV['TWILIO_ACCOUNT_SID'],
      ENV['TWILIO_AUTH_TOKEN'])

    client.messages.create(
      from: ENV['TWILIO_PHONE_NUMBER'],
      to: @recipient, # the recipient is stored on the instance
      body: self.get_translation()
    )
  end
end
```

See the full changeset for additional comments.

There's more we can do, but this is a great starting spot!